### PR TITLE
Fixing `tess_stars2px_function_entry` exit error and updating dependencies 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tess-locator"
-version = "0.6.dev"
+version = "0.6.0"
 description = "Fast offline queries of TESS FFI positions and filenames."
 license = "MIT"
 authors = ["Geert Barentsen <hello@geert.io>",
@@ -23,7 +23,7 @@ numpy = "^1.23.0"
 tqdm = "^4.51.1"
 attrs = "^23.1.0"
 tess-point = "^0.8"
-tess-cloud = "^0.4"
+tess-cloud = "^0.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,14 +16,14 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
-astropy = ">= 4.0"
-pandas = ">= 1.0"
-numpy = ">= 1.19"
-tqdm = ">= 4.51"
-attrs = ">= 20.3.0"
-tess-point = ">= 0.6.1"
-tess-cloud = ">=0.3.1"
+python = "^3.8"
+astropy = "^5.2.0"
+pandas = "^1.4.4"
+numpy = "^1.23.0"
+tqdm = "^4.51.1"
+attrs = "^23.1.0"
+tess-point = "^0.8"
+tess-cloud = "^0.4"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0"

--- a/src/tess_locator/__init__.py
+++ b/src/tess_locator/__init__.py
@@ -2,7 +2,7 @@ import logging
 from pathlib import Path
 import tess_stars2px  # provided by the `tess-point` package
 
-__version__ = "0.6.dev"
+__version__ = "0.6.0"
 
 # Where does this package store its embedded data?
 PACKAGEDIR: Path = Path(__file__).parent.absolute()

--- a/src/tess_locator/locate.py
+++ b/src/tess_locator/locate.py
@@ -44,6 +44,9 @@ def locate(
     dec = np.atleast_1d(target.dec.to("deg").value)
     result = []
     for idx in range(len(ra)):
+        # tess-point will exit if trySector < 0
+        if isinstance(sectors_to_search[idx], np.int64) and sectors_to_search[idx] < 0:
+            continue
         (
             _,
             _,

--- a/src/tess_locator/locate.py
+++ b/src/tess_locator/locate.py
@@ -63,7 +63,7 @@ def locate(
                 trySector=sectors_to_search[idx],
                 aberrate=aberrate,
             )
-        except:
+        except SystemExit:
             continue
 
         for idx_out in range(len(out_sector)):

--- a/src/tess_locator/locate.py
+++ b/src/tess_locator/locate.py
@@ -44,22 +44,27 @@ def locate(
     dec = np.atleast_1d(target.dec.to("deg").value)
     result = []
     for idx in range(len(ra)):
-        # tess-point will exit if trySector < 0
-        if isinstance(sectors_to_search[idx], np.int64) and sectors_to_search[idx] < 0:
+        # tess_stars2px_function_entry will exit with SystemExit: 1 if trySector < 0
+        try:
+            (
+                _,
+                _,
+                _,
+                out_sector,
+                out_camera,
+                out_ccd,
+                out_col,
+                out_row,
+                scinfo,
+            ) = tess_stars2px_function_entry(
+                0,
+                ra[idx],
+                dec[idx],
+                trySector=sectors_to_search[idx],
+                aberrate=aberrate,
+            )
+        except:
             continue
-        (
-            _,
-            _,
-            _,
-            out_sector,
-            out_camera,
-            out_ccd,
-            out_col,
-            out_row,
-            scinfo,
-        ) = tess_stars2px_function_entry(
-            0, ra[idx], dec[idx], trySector=sectors_to_search[idx], aberrate=aberrate
-        )
 
         for idx_out in range(len(out_sector)):
             if out_sector[idx_out] < 0:

--- a/tests/test_locate.py
+++ b/tests/test_locate.py
@@ -18,7 +18,7 @@ def test_pi_men():
     """Tests `locate()` against `astroquery.mast.Tesscut.get_sectors()`"""
     # Query using Tesscut
     crd = SkyCoord(ra=84.291188, dec=-80.46911982, unit="deg")
-    mast_result = Tesscut.get_sectors(crd)
+    mast_result = Tesscut.get_sectors(coordinates=crd)
     # Query using our tool
     our_result = locate(crd)
     # Do the sector, camera, and ccd numbers all match?
@@ -31,7 +31,7 @@ def test_pi_men():
     assert our_result_df.iloc[0 : len(mast_result_df)].equals(mast_result_df)
     # Can we search by passing a string instead of the coordinates?
     our_result2 = locate("Pi Men")
-    assert our_result.to_pandas().round(2).equals(our_result2.to_pandas().round(2))
+    assert our_result.to_pandas().round(1).equals(our_result2.to_pandas().round(1))
 
 
 def test_scalar_vs_nonscalar_coordinate():


### PR DESCRIPTION
Fixes `tess_stars2px_function_entry` exit error when `trySector = -1` which makes `locate` exit with SystemExit: 1 from `tess_stars2px_function_entry`. 

Updates dependencies to:
- astropy = "^5.2.0"
- pandas = "^1.4.4"
- numpy = "^1.23.0"